### PR TITLE
Recongize Seeed variant for nrf52 core

### DIFF
--- a/adafruit.py
+++ b/adafruit.py
@@ -31,7 +31,9 @@ platform = env.PioPlatform()
 board = env.BoardConfig()
 variant = board.get("build.variant")
 
-FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoadafruitnrf52")
+is_xiao_board = board.id in ("xiaoblesense_adafruit", "xiaoble_adafruit")
+framework_pkg = "framework-arduinoadafruitnrf52-seeed" if is_xiao_board else "framework-arduinoadafruitnrf52"
+FRAMEWORK_DIR = platform.get_package_dir(framework_pkg)
 assert isdir(FRAMEWORK_DIR)
 
 CMSIS_DIR = platform.get_package_dir("framework-cmsis")


### PR DESCRIPTION
Per https://github.com/maxgerhardt/builder-framework-arduino-nrf5/commit/cc60b35642984f2244491086664463784f90da06

Needed for building the `_adafruit` variants for the boards introduced in https://github.com/platformio/platform-nordicnrf52/pull/151.